### PR TITLE
Add  sassc gem to fix initial server start error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'sprockets-rails' # The original asset pipeline for Rails
 gem 'cssbundling-rails' # Bundle and process CSS
 gem 'jsbundling-rails' # Bundle and transpile JavaScript
 # gem 'image_processing' # Use Active Storage variants
-
+gem 'sassc'
 
 # Translations
 # gem 'rails-i18n', '~> 6.0.0' # Translations for Rails


### PR DESCRIPTION
## What happened 👀
Add **sassc** gem to fix error that generates on fresh installment from develop branch of [nimblehq/rails-templates](https://github.com/nimblehq/rails-templates)


## Insight 📝

Initial project setup from **develop** branch adds below error when **make dev** is run to start the project
<img width="1237" alt="Screen Shot 2023-05-15 at 5 30 00 PM" src="https://github.com/mosharaf13/google-scrapper-ruby/assets/12990839/5333fc03-e03e-4276-a523-247a9ec6afab">

Adding **sassc** gem in Gemfile fixes it.

## Proof Of Work 📹


Runs in terminal without any error

<img width="963" alt="Screen Shot 2023-05-15 at 5 35 39 PM" src="https://github.com/mosharaf13/google-scrapper-ruby/assets/12990839/f5880ab5-9f5d-49fe-bf84-b5b3a5902b76">


Runs in browser properly

<img width="1439" alt="Screen Shot 2023-05-15 at 5 38 27 PM" src="https://github.com/mosharaf13/google-scrapper-ruby/assets/12990839/d007c4f2-dd63-4b97-ba4d-6b4dab94283e">

